### PR TITLE
Remove exposed Google Cloud's Web client id

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Plitso</string>
-    <string name="web_client_id">467783773422-55d2gmdn5q0pfof95lqld6aaqhksu295.apps.googleusercontent.com</string>
     <string name="notification_permission_request">Notification Permission Request</string>
     <string name="permission_is_required_to_show_app_notifications">Permission is required to show app notifications</string>
 </resources>


### PR DESCRIPTION
The Google Cloud Web Client ID was mistakenly left exposed in the strings.xml file, despite already being properly configured in local.properties. This refactor removes the hardcoded value from strings.xml to prevent potential security risks.